### PR TITLE
Here is some initial work towards flatpak packaging

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+FILE=$1
+
+APPID=`basename $FILE .json`
+
+echo ========== Building $APPID ================
+flatpak-builder --force-clean --ccache --require-changes --repo=repo --subject="Nightly build of ${APPID}, `date`" ${EXPORT_ARGS-} app $FILE
+

--- a/build/mediawriter-configure
+++ b/build/mediawriter-configure
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+qmake -makefile -recursive

--- a/build/org.fedoraproject.MediaWriter.json
+++ b/build/org.fedoraproject.MediaWriter.json
@@ -1,0 +1,28 @@
+{
+    "id": "org.fedoraproject.MediaWriter",
+    "runtime": "org.kde.Platform",
+    "runtime-version": "master",
+    "sdk": "org.kde.Sdk",
+    "command": "app",
+    "finish-args": [
+        "--socket=x11",
+        "--filesystem=host"
+    ],
+    "modules": [
+        {
+            "name": "MediaWriter",
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "http://github.com/MartinBriza/MediaWriter",
+                    "branch": "master"
+                },
+                {
+                    "type": "file",
+                    "path": "mediawriter-configure",
+                    "dest-filename": "configure"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
for MediaWriter. To make my life easier, I decided to
just use the kde runtime, which has all the qt5 bits
in it.

Sadly, the build currently fails, with an error that
I can't make sense of. Maybe you can give it a quick look ?

To try this out, just

cd build
./build.sh org.fedoraproject.MediaWriter.json