### PR TITLE
Add clang format configuration

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,33 @@
+---
+Language: Cpp
+Standard: Cpp11
+AccessModifierOffset: -4
+UseTab: Never
+IndentWidth: 4
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 8
+AlignAfterOpenBracket: DontAlign
+# In casts the pointer should be on the left.
+PointerAlignment: Right
+DerivePointerAlignment: false
+AllowShortIfStatementsOnASingleLine: false
+ColumnLimit: 0
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterClass: false
+  AfterControlStatement: false
+  AfterEnum: false
+  # If there are constructor initializers there might be a break.
+  AfterFunction: false
+  AfterNamespace: false
+  AfterObjCDeclaration: false
+  AfterStruct: false
+  AfterUnion: false
+  BeforeCatch: false
+  BeforeElse: true
+  IndentBraces: false
+SpaceAfterCStyleCast: true
+# There should be a space before the brace too.
+Cpp11BracedListStyle: false
+SortIncludes: false
+MaxEmptyLinesToKeep: 1


### PR DESCRIPTION
Clang-Format is not a silver bullet but it's a good and popular tool for source code formatting.

This configuration was run against the entire source code and it does conform to the style the source code uses except for the cases which are listed in issues below.

Note: The idea of having this is not to reformat the entire source code based on this clang-format configuration but to be able to format the changed lines with Clang-Format to avoid introduction of more inconsistency across the source code when more developers with different taste start to work on this.

## Issues

These are issues based on observations how the source code is currently
formatted. These issues exist because Clang-Format does not seem to be able to handle them. The issues below are therefore open for discussion.

I do think that even if these issues will not be resolved and this will not be merged this PR will be a good reference for other developers who are not sure what formatting style they should use in this project.

### Pointer alignment in casts

Pointers should be aligned on the right but no extra space should be added if a pointer is used as part of a type in a cast.

Expected result: `static_cast<int*>(foo) == (int*) foo;`

Actual result: `static_cast<int *>(foo) == (int *) foo;`

### Brace initialization

There should be a space between the variable and the brace.

Expected result: `int foo { 1 };`

Actual result: ` int foo{ 1 };`

### Preprocessor indention

In ifdef, ifndef there should be an extra space to specify indention.

Expected result:
```
#ifdef __linux__
# include "linuxdrivemanager.h"
#endif // __linux__
```

Actual result:
```
#ifdef __linux__
#include "linuxdrivemanager.h"
#endif // __linux__
```

### Unclear - Brace wrapping after constructor initializers

In most cases there's a break before the brace if there are constructor initializers present.

At the time I looked at it I recorded 8 cases where this is not the case and 21 where this is the case.
