### PR TITLE
Remove unused variable dd

### DIFF
--- a/helper/linux/writejob.h
+++ b/helper/linux/writejob.h
@@ -59,8 +59,6 @@ private:
     QTextStream err { stderr };
     QDBusUnixFileDescriptor fd { -1 };
     QFileSystemWatcher watcher { };
-
-    QProcess *dd { nullptr };
 };
 
 #endif // WRITEJOB_H

--- a/helper/mac/writejob.cpp
+++ b/helper/mac/writejob.cpp
@@ -32,7 +32,7 @@
 #include "isomd5/libcheckisomd5.h"
 
 WriteJob::WriteJob(const QString &what, const QString &where)
-    : QObject(nullptr), what(what), where(where), dd(new QProcess(this))
+    : QObject(nullptr), what(what), where(where)
 {
     connect(&watcher, &QFileSystemWatcher::fileChanged, this, &WriteJob::onFileChanged);
     if (what.endsWith(".part")) {

--- a/helper/mac/writejob.h
+++ b/helper/mac/writejob.h
@@ -56,8 +56,6 @@ private:
 
     QFileSystemWatcher watcher { };
 
-    QProcess *dd;
-
     const int BLOCK_SIZE { 512 * 1024 };
 };
 

--- a/helper/win/writejob.cpp
+++ b/helper/win/writejob.cpp
@@ -37,7 +37,7 @@
 
 
 WriteJob::WriteJob(const QString &what, const QString &where)
-    : QObject(nullptr), what(what), dd(new QProcess(this))
+    : QObject(nullptr), what(what)
 {
     bool ok = false;
     this->where = where.toInt(&ok);

--- a/helper/win/writejob.h
+++ b/helper/win/writejob.h
@@ -71,8 +71,6 @@ private:
 
     QFileSystemWatcher watcher { };
 
-    QProcess *dd;
-
     const int BLOCK_SIZE { 512 * 128 };
 };
 


### PR DESCRIPTION
* Remove from linux helper since it's not used anymore since 397c29857c4a2d7cb3699319b0c8b871b9ffc582.
* Remove from windows helper since it's not used anymore since 92032e6fdb8165733998d5a106f0987a65e8e370.
* Remove from mac helper since it was never used.