### PR TITLE
Improve memory management of page-aligned buffer

### DIFF
--- a/helper/linux/writejob.h
+++ b/helper/linux/writejob.h
@@ -27,6 +27,12 @@
 #include <QDBusUnixFileDescriptor>
 #include <QFileSystemWatcher>
 
+#include <unistd.h>
+
+#include <memory>
+#include <tuple>
+#include <utility>
+
 #ifndef MEDIAWRITER_LZMA_LIMIT
 // 256MB memory limit for the decompressor
 # define MEDIAWRITER_LZMA_LIMIT (1024*1024*256)
@@ -46,9 +52,6 @@ public:
     bool writeCompressed(int fd);
     bool writePlain(int fd);
     bool check(int fd);
-
-    // in pages (1024 * 2048 likely)
-    const int BUFFER_SIZE { 1024 };
 public slots:
     void work();
     void onFileChanged(const QString &path);
@@ -60,5 +63,7 @@ private:
     QDBusUnixFileDescriptor fd { -1 };
     QFileSystemWatcher watcher { };
 };
+
+std::tuple<std::unique_ptr<char[]>, char*, std::size_t> pageAlignedBuffer(std::size_t pages = 1024);
 
 #endif // WRITEJOB_H


### PR DESCRIPTION
Fix memory leak in WriteJob::writeCompressed of the linux helper.

~~Use C++14 for the linux helper so that `std::make_unique` can be used.~~

So this is an interesting case to review in my humbly opinion. As you can see I used the STL and it wasn't used in this project before. So I hope that there is stuff to talk about.