### PR TITLE
Correct statement order

### DIFF
--- a/app/linuxdrivemanager.cpp
+++ b/app/linuxdrivemanager.cpp
@@ -348,6 +348,6 @@ void LinuxDrive::onErrorOccurred(QProcess::ProcessError e) {
     m_image->setErrorString(errorMessage);
     m_process->deleteLater();
     m_process = nullptr;
-    m_image = nullptr;
     m_image->setStatus(ReleaseVariant::FAILED);
+    m_image = nullptr;
 }


### PR DESCRIPTION
Set status before detaching `m_image` as intended by 4b001dddc17d47d892393f6d46286e746aeed6e7.

Fix crash by not trying to call an object pointer on null.

Probably the commit message is bad. I'm open to suggestions.