### PR TITLE
Add updated Fedora image (respin)

### DIFF
--- a/src/app/data/assets/releases.json
+++ b/src/app/data/assets/releases.json
@@ -2,6 +2,15 @@
    {
       "subvariant":"Workstation",
       "variant":"Workstation",
+      "version":"36 Live",
+      "link":"https://dl.fedoraproject.org/pub/alt/live-respins/F36-WORK-x86_64-LIVE-20220701.iso",
+      "sha256":"",
+      "arch":"x86_64",
+      "size":""
+   },
+   {
+      "subvariant":"Workstation",
+      "variant":"Workstation",
       "version":"36 Beta",
       "link":"https://download.fedoraproject.org/pub/fedora/linux/releases/test/36_Beta/Workstation/aarch64/images/Fedora-Workstation-36_Beta-1.4.aarch64.raw.xz",
       "sha256":"ba0fb3a94e5fc6fbbbacd93565c8943ccf84d5afb9153abe6b48de3f96273758",


### PR DESCRIPTION
Addresses #528.

Checksums are absent, and some C++ code needs to be written to fetch available respin version from https://dl.fedoraproject.org/pub/alt/live-respins/

I write it in Python, but not sure about my C++.