### PR TITLE
Rename appdata to metainfo

### DIFF
--- a/dist/fedora/mediawriter.spec
+++ b/dist/fedora/mediawriter.spec
@@ -51,12 +51,12 @@ like flash drives or memory cards.
 %cmake_install
 
 %check
-appstream-util validate-relax --nonet %{buildroot}/%{_datadir}/metainfo/org.fedoraproject.MediaWriter.appdata.xml
+appstream-util validate-relax --nonet %{buildroot}/%{_datadir}/metainfo/org.fedoraproject.MediaWriter.metainfo.xml
 
 %files
 %{_bindir}/%{name}
 %{_libexecdir}/%{name}/
-%{_datadir}/metainfo/org.fedoraproject.MediaWriter.appdata.xml
+%{_datadir}/metainfo/org.fedoraproject.MediaWriter.metainfo.xml
 %{_datadir}/applications/org.fedoraproject.MediaWriter.desktop
 %{_datadir}/icons/hicolor/16x16/apps/org.fedoraproject.MediaWriter.png
 %{_datadir}/icons/hicolor/22x22/apps/org.fedoraproject.MediaWriter.png

--- a/po/build-translations.sh
+++ b/po/build-translations.sh
@@ -22,7 +22,7 @@ for i in `ls mediawriter_*.po`; do
     msgfmt $i -o "${LANGCODE}.mo"
 done
 
-itstool -i as-metainfo.its -j ../src/app/data/org.fedoraproject.MediaWriter.appdata.xml.in -o ../src/app/data/org.fedoraproject.MediaWriter.appdata.xml *.mo
+itstool -i as-metainfo.its -j ../src/app/data/org.fedoraproject.MediaWriter.metainfo.xml.in -o ../src/app/data/org.fedoraproject.MediaWriter.metainfo.xml *.mo
 
 rm -f *.mo
 

--- a/po/generate-pot-files.sh
+++ b/po/generate-pot-files.sh
@@ -4,6 +4,6 @@ rm -f mediawriter.pot mediawriter.ts
 lupdate-qt6 ../src/app/qml.qrc ../src/app/*.cpp ../src/app/*.h ../src/helper/linux/*.cpp ../src/helper/mac/*.cpp ../src/helper/win/*.cpp -ts mediawriter.ts
 lconvert-qt6 -of po -o app.pot mediawriter.ts
 xgettext ../src/app/data/org.fedoraproject.MediaWriter.desktop -o desktop.pot
-itstool -i as-metainfo.its -o appstream.pot ../src/app/data/org.fedoraproject.MediaWriter.appdata.xml.in
+itstool -i as-metainfo.its -o appstream.pot ../src/app/data/org.fedoraproject.MediaWriter.metainfo.xml.in
 msgcat *.pot > mediawriter.pot
 rm app.pot appstream.pot desktop.pot

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -105,5 +105,5 @@ install(TARGETS mediawriter
 if (UNIX AND NOT APPLE)
     install(DIRECTORY data/icons/hicolor/ DESTINATION ${CMAKE_INSTALL_FULL_DATADIR}/icons/hicolor)
     install(FILES data/org.fedoraproject.MediaWriter.desktop DESTINATION ${CMAKE_INSTALL_FULL_DATADIR}/applications)
-    install(FILES data/org.fedoraproject.MediaWriter.appdata.xml DESTINATION ${CMAKE_INSTALL_FULL_DATADIR}/metainfo)
+    install(FILES data/org.fedoraproject.MediaWriter.metainfo.xml DESTINATION ${CMAKE_INSTALL_FULL_DATADIR}/metainfo)
 endif()

--- a/src/app/data/org.fedoraproject.MediaWriter.metainfo.xml
+++ b/src/app/data/org.fedoraproject.MediaWriter.metainfo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright 2016 Jiri Eischmann <eischmann@redhat.com> -->
-<component type="desktop">
+<component type="desktop-application">
 	<id>org.fedoraproject.MediaWriter.desktop</id>
 	<launchable type="desktop-id">org.fedoraproject.MediaWriter.desktop</launchable>
 	<project_license>GPL-2.0+</project_license>

--- a/src/app/data/org.fedoraproject.MediaWriter.metainfo.xml.in
+++ b/src/app/data/org.fedoraproject.MediaWriter.metainfo.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright 2016 Jiri Eischmann <eischmann@redhat.com> -->
 
-<component type="desktop">
+<component type="desktop-application">
 	<id>org.fedoraproject.MediaWriter.desktop</id>
 	<launchable type="desktop-id">org.fedoraproject.MediaWriter.desktop</launchable>
 	<project_license>GPL-2.0+</project_license>


### PR DESCRIPTION
The appdata.xml suffix is deprecated.

Also change the deprecated desktop component type to desktop-application.